### PR TITLE
bug: fix carrierName typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 .pub/
 
 build/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/

--- a/ios/Classes/Carrier.swift
+++ b/ios/Classes/Carrier.swift
@@ -39,7 +39,7 @@ final public class Carrier {
 
     /// Returns the name of the user’s home cellular service provider.
     public var carrierName: String? {
-        return carrier?.carrierName3
+        return carrier?.carrierName
     }
 
     /// Returns the ISO country code for the user’s cellular service provider.


### PR DESCRIPTION
Fixed the ios compile error:
carrrierName3 :no_entry:️
carrierName :white_check_mark: 

Also, added the .gitignore for intelliJ related ones